### PR TITLE
Updated the code to support official OTel (from v1.12.0)

### DIFF
--- a/DatadogTrace/Sources/OpenTelemetry/NOPOTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/NOPOTelSpan.swift
@@ -37,6 +37,14 @@ internal class NOPOTelSpan: Span {
 
     func addEvent(name: String, attributes: [String: OpenTelemetryApi.AttributeValue], timestamp: Date) {}
 
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String : OpenTelemetryApi.AttributeValue], timestamp: Date) {}
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String : OpenTelemetryApi.AttributeValue]) {}
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, timestamp: Date) {}
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException) {}
+
     func end() {
         OpenTelemetry.instance.contextProvider.removeContextForSpan(self)
     }

--- a/DatadogTrace/Sources/OpenTelemetry/NOPOTelSpanBuilder.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/NOPOTelSpanBuilder.swift
@@ -55,4 +55,15 @@ internal class NOPOTelSpanBuilder: SpanBuilder {
     func setActive(_ active: Bool) -> Self {
         return self
     }
+
+    @discardableResult
+    func withActiveSpan<T>(_ operation: (any OpenTelemetryApi.SpanBase) throws -> T) rethrows -> T {
+        return try operation(NOPOTelSpan())
+    }
+
+    @discardableResult
+    func withActiveSpan<T>(_ operation: (any OpenTelemetryApi.SpanBase) async throws -> T) async rethrows -> T {
+        return try await operation(NOPOTelSpan())
+    }
+
 }

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpan.swift
@@ -154,6 +154,22 @@ internal class OTelSpan: OpenTelemetryApi.Span {
         DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
     }
 
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String : OpenTelemetryApi.AttributeValue], timestamp: Date) {
+        DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
+    }
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, attributes: [String : OpenTelemetryApi.AttributeValue]) {
+        DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
+    }
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException, timestamp: Date) {
+        DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
+    }
+
+    func recordException(_ exception: any OpenTelemetryApi.SpanException) {
+        DD.logger.warn("\(#function) is not yet supported in `DatadogTrace`")
+    }
+
     func end() {
         end(time: Date())
     }

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpanBuilder.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpanBuilder.swift
@@ -95,6 +95,22 @@ internal class OTelSpanBuilder: OpenTelemetryApi.SpanBuilder {
         return self
     }
 
+    func withActiveSpan<T>(_ operation: (any OpenTelemetryApi.SpanBase) throws -> T) rethrows -> T {
+        let span = self.startSpan()
+        defer {
+            span.end()
+        }
+        return try operation(span)
+    }
+
+    func withActiveSpan<T>(_ operation: (any OpenTelemetryApi.SpanBase) async throws -> T) async rethrows -> T {
+        let span = self.startSpan()
+        defer {
+            span.end()
+        }
+        return try await operation(span)
+    }
+
     func startSpan() -> OpenTelemetryApi.Span {
         let parentContext = parent.context()
         let traceId: TraceId

--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,7 @@
 import PackageDescription
 import Foundation
 
-let opentelemetry = ProcessInfo.processInfo.environment["OTEL_SWIFT"] != nil ? 
-    (name: "opentelemetry-swift", url: "https://github.com/open-telemetry/opentelemetry-swift.git") :
-    (name: "opentelemetry-swift-packages", url: "https://github.com/DataDog/opentelemetry-swift-packages.git")
+let opentelemetry = (name: "opentelemetry-swift", url: "https://github.com/open-telemetry/opentelemetry-swift.git")
 
 let internalSwiftSettings: [SwiftSetting] = ProcessInfo.processInfo.environment["DD_BENCHMARK"] != nil ?
     [.define("DD_BENCHMARK")] : []
@@ -13,9 +11,9 @@ let internalSwiftSettings: [SwiftSetting] = ProcessInfo.processInfo.environment[
 let package = Package(
     name: "Datadog",
     platforms: [
-        .iOS(.v12),
-        .tvOS(.v12),
-        .macOS(.v12),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .macOS(.v13),
         .watchOS(.v7)
     ],
     products: [
@@ -54,7 +52,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.2"),
-        .package(url: opentelemetry.url, exact: "1.6.0"),
+        .package(url: opentelemetry.url, .upToNextMinor(from: "1.12.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
### What and why?

This PR introduces support for the [official version of OTel](https://github.com/open-telemetry/opentelemetry-swift/).

### How?
- Removed reliance on [DD's internal OpenTelemetry-Swift fork](https://github.com/DataDog/opentelemetry-swift-packages).
- Updated the version from `1.6.0` to `1.12.0` and implemented the necessary changes (e.g., added missing protocol implementations and updated the minimum iOS/tvOS/macOS version to `v13`).